### PR TITLE
Fix code scanning alert no. 74: Incomplete multi-character sanitization

### DIFF
--- a/public/plugins/summernote/summernote.js
+++ b/public/plugins/summernote/summernote.js
@@ -6476,32 +6476,36 @@ var CodeView = /*#__PURE__*/function () {
 
         if (this.options.codeviewIframeFilter) {
           var whitelist = this.options.codeviewIframeWhitelistSrc.concat(this.options.codeviewIframeWhitelistSrcBase);
-          value = value.replace(/(<iframe.*?>.*?(?:<\/iframe>)?)/gi, function (tag) {
-            // remove if src attribute is duplicated
-            if (/<.+src(?==?('|"|\s)?)[\s\S]+src(?=('|"|\s)?)[^>]*?>/i.test(tag)) {
-              return '';
-            }
-
-            var _iterator = _createForOfIteratorHelper(whitelist),
-                _step;
-
-            try {
-              for (_iterator.s(); !(_step = _iterator.n()).done;) {
-                var src = _step.value;
-
-                // pass if src is trusted
-                if (new RegExp('src="(https?:)?\/\/' + src.replace(/[-\/\\^$*+?.()|[\]{}]/g, '\\$&') + '\/(.+)"').test(tag)) {
-                  return tag;
-                }
+          let previous;
+          do {
+            previous = value;
+            value = value.replace(/(<iframe.*?>.*?(?:<\/iframe>)?)/gi, function (tag) {
+              // remove if src attribute is duplicated
+              if (/<.+src(?==?('|"|\s)?)[\s\S]+src(?=('|"|\s)?)[^>]*?>/i.test(tag)) {
+                return '';
               }
-            } catch (err) {
-              _iterator.e(err);
-            } finally {
-              _iterator.f();
-            }
 
-            return '';
-          });
+              var _iterator = _createForOfIteratorHelper(whitelist),
+                  _step;
+
+              try {
+                for (_iterator.s(); !(_step = _iterator.n()).done;) {
+                  var src = _step.value;
+
+                  // pass if src is trusted
+                  if (new RegExp('src="(https?:)?\/\/' + src.replace(/[-\/\\^$*+?.()|[\]{}]/g, '\\$&') + '\/(.+)"').test(tag)) {
+                    return tag;
+                  }
+                }
+              } catch (err) {
+                _iterator.e(err);
+              } finally {
+                _iterator.f();
+              }
+
+              return '';
+            });
+          } while (value !== previous);
         }
       }
 


### PR DESCRIPTION
Fixes [https://github.com/zyab1ik/blogify/security/code-scanning/74](https://github.com/zyab1ik/blogify/security/code-scanning/74)

To fix the problem, we need to ensure that the regular expression replacement is applied repeatedly until no more replacements can be performed. This will ensure that all instances of the targeted pattern are removed from the input. We can achieve this by using a loop that continues to apply the replacement until the input remains unchanged.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
