### PR TITLE
Fix code scanning alert no. 43: DOM text reinterpreted as HTML

### DIFF
--- a/public/plugins/summernote/plugin/databasic/summernote-ext-databasic.js
+++ b/public/plugins/summernote/plugin/databasic/summernote-ext-databasic.js
@@ -170,7 +170,7 @@
 
     self.setContent = function($node) {
       $node.html('<p contenteditable="false">' + self.icon + ' ' + lang.databasic.name + ': ' +
-        $node.attr('data-test') + '</p>');
+        escapeHtml($node.attr('data-test')) + '</p>');
     };
 
     self.updateNode = function(info) {
@@ -288,4 +288,16 @@
     },
 
   });
+    function escapeHtml(text) {
+      return text.replace(/[&<>"']/g, function(match) {
+        const escapeMap = {
+          '&': '&amp;',
+          '<': '&lt;',
+          '>': '&gt;',
+          '"': '&quot;',
+          "'": '&#39;'
+        };
+        return escapeMap[match];
+      });
+    }
 }));


### PR DESCRIPTION
Fixes [https://github.com/zyab1ik/blogify/security/code-scanning/43](https://github.com/zyab1ik/blogify/security/code-scanning/43)

To fix the problem, we need to ensure that any user-controlled data is properly escaped before being inserted into the HTML. This can be achieved by using a function that escapes HTML special characters, preventing the execution of any injected scripts.

The best way to fix this issue without changing existing functionality is to create a utility function that escapes HTML special characters and use this function to sanitize the `data-test` attribute before concatenating it into the HTML string.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
