### PR TITLE
Fix code scanning alert no. 72: Incomplete multi-character sanitization

### DIFF
--- a/public/plugins/summernote/summernote-lite.js
+++ b/public/plugins/summernote/summernote-lite.js
@@ -6476,32 +6476,36 @@ var CodeView = /*#__PURE__*/function () {
 
         if (this.options.codeviewIframeFilter) {
           var whitelist = this.options.codeviewIframeWhitelistSrc.concat(this.options.codeviewIframeWhitelistSrcBase);
-          value = value.replace(/(<iframe.*?>.*?(?:<\/iframe>)?)/gi, function (tag) {
-            // remove if src attribute is duplicated
-            if (/<.+src(?==?('|"|\s)?)[\s\S]+src(?=('|"|\s)?)[^>]*?>/i.test(tag)) {
-              return '';
-            }
-
-            var _iterator = _createForOfIteratorHelper(whitelist),
-                _step;
-
-            try {
-              for (_iterator.s(); !(_step = _iterator.n()).done;) {
-                var src = _step.value;
-
-                // pass if src is trusted
-                if (new RegExp('src="(https?:)?\/\/' + src.replace(/[-\/\\^$*+?.()|[\]{}]/g, '\\$&') + '\/(.+)"').test(tag)) {
-                  return tag;
-                }
+          var previous;
+          do {
+            previous = value;
+            value = value.replace(/(<iframe.*?>.*?(?:<\/iframe>)?)/gi, function (tag) {
+              // remove if src attribute is duplicated
+              if (/<.+src(?==?('|"|\s)?)[\s\S]+src(?=('|"|\s)?)[^>]*?>/i.test(tag)) {
+                return '';
               }
-            } catch (err) {
-              _iterator.e(err);
-            } finally {
-              _iterator.f();
-            }
 
-            return '';
-          });
+              var _iterator = _createForOfIteratorHelper(whitelist),
+                  _step;
+
+              try {
+                for (_iterator.s(); !(_step = _iterator.n()).done;) {
+                  var src = _step.value;
+
+                  // pass if src is trusted
+                  if (new RegExp('src="(https?:)?\/\/' + src.replace(/[-\/\\^$*+?.()|[\]{}]/g, '\\$&') + '\/(.+)"').test(tag)) {
+                    return tag;
+                  }
+                }
+              } catch (err) {
+                _iterator.e(err);
+              } finally {
+                _iterator.f();
+              }
+
+              return '';
+            });
+          } while (value !== previous);
         }
       }
 


### PR DESCRIPTION
Fixes [https://github.com/zyab1ik/blogify/security/code-scanning/72](https://github.com/zyab1ik/blogify/security/code-scanning/72)

To fix the issue, we should ensure that all instances of the targeted pattern are removed from the input. One effective way to achieve this is to apply the regular expression replacement repeatedly until no more replacements can be performed. This approach ensures that all `<iframe>` tags are removed, regardless of their nesting or consecutive appearance.

We will modify the `purify` method to repeatedly apply the regular expression replacement for `<iframe>` tags until the input no longer changes. This will ensure that all potentially unsafe `<iframe>` tags are removed from the sanitized input.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
