### PR TITLE
Fix code scanning alert no. 41: DOM text reinterpreted as HTML

### DIFF
--- a/public/plugins/bootstrap/js/bootstrap.js
+++ b/public/plugins/bootstrap/js/bootstrap.js
@@ -1097,7 +1097,7 @@
         return;
       }
 
-      var target = $__default["default"](selector)[0];
+      var target = $__default["default"].find(selector)[0];
 
       if (!target || !$__default["default"](target).hasClass(CLASS_NAME_CAROUSEL)) {
         return;


### PR DESCRIPTION
Fixes [https://github.com/zyab1ik/blogify/security/code-scanning/41](https://github.com/zyab1ik/blogify/security/code-scanning/41)

To fix the problem, we need to ensure that the `selector` value is properly sanitized before being used in the jQuery function. One way to achieve this is by using the `$.find` method instead of `$`, as `$.find` will interpret the `selector` strictly as a CSS selector and not as HTML. This change will prevent any potential XSS attacks by ensuring that the `selector` is not reinterpreted as HTML.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
