### PR TITLE
Fix code scanning alert no. 19: Unsafe jQuery plugin

### DIFF
--- a/public/assets/vendors/bootstrap/js/src/scrollspy.js
+++ b/public/assets/vendors/bootstrap/js/src/scrollspy.js
@@ -168,7 +168,7 @@ class ScrollSpy {
     }
 
     if (typeof config.target !== 'string') {
-      let id = $(config.target).attr('id')
+      let id = $.find(config.target).attr('id')
       if (!id) {
         id = Util.getUID(NAME)
         $(config.target).attr('id', id)


### PR DESCRIPTION
Fixes [https://github.com/zyab1ik/blogify/security/code-scanning/19](https://github.com/zyab1ik/blogify/security/code-scanning/19)

To fix the problem, we need to ensure that the `config.target` parameter is always treated as a CSS selector and not as HTML. This can be achieved by using the `jQuery.find` method instead of directly passing `config.target` to the jQuery selector. This change will prevent the evaluation of `config.target` as HTML, mitigating the risk of XSS.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
