### PR TITLE
Fix code scanning alert no. 21: Unsafe jQuery plugin

### DIFF
--- a/public/plugins/jquery-ui/jquery-ui.js
+++ b/public/plugins/jquery-ui/jquery-ui.js
@@ -905,7 +905,7 @@ $.fn.position = function( options ) {
 		// Make sure string options are treated as CSS selectors
 		target = typeof options.of === "string" ?
 			$( document ).find( options.of ) :
-			$( options.of ),
+			$( options.of ).find( options.of ),
 
 		within = $.position.getWithinInfo( options.within ),
 		scrollInfo = $.position.getScrollInfo( within ),


### PR DESCRIPTION
Fixes [https://github.com/zyab1ik/blogify/security/code-scanning/21](https://github.com/zyab1ik/blogify/security/code-scanning/21)

To fix the problem, we need to ensure that the `options.of` parameter is always treated as a CSS selector and not as HTML. This can be achieved by using the `jQuery.find` method instead of directly passing `options.of` to the jQuery selector. This change will prevent the evaluation of `options.of` as HTML, mitigating the risk of XSS.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
