### PR TITLE
Fix code scanning alert no. 20: Unsafe jQuery plugin

### DIFF
--- a/public/assets/vendors/bootstrap/js/src/scrollspy.js
+++ b/public/assets/vendors/bootstrap/js/src/scrollspy.js
@@ -168,10 +168,10 @@ class ScrollSpy {
     }
 
     if (typeof config.target !== 'string') {
-      let id = $.find(config.target).attr('id')
+      let id = $(document).find(config.target).attr('id')
       if (!id) {
         id = Util.getUID(NAME)
-        $(config.target).attr('id', id)
+        $(document).find(config.target).attr('id', id)
       }
       config.target = `#${id}`
     }


### PR DESCRIPTION
Fixes [https://github.com/zyab1ik/blogify/security/code-scanning/20](https://github.com/zyab1ik/blogify/security/code-scanning/20)

To fix the problem, we need to ensure that `config.target` is always interpreted as a CSS selector and not as HTML. This can be achieved by using `jQuery.find` instead of `jQuery` to select the target element. Additionally, we should document that the `target` option should be a valid CSS selector.

1. Modify the `_getConfig` method to use `jQuery.find` for selecting the target element.
2. Ensure that the `target` option is documented as a CSS selector.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
