### PR TITLE
Fix code scanning alert no. 50: Incomplete string escaping or encoding

### DIFF
--- a/public/plugins/moment/moment-with-locales.js
+++ b/public/plugins/moment/moment-with-locales.js
@@ -800,7 +800,7 @@
     function unescapeFormat(s) {
         return regexEscape(
             s
-                .replace('\\', '')
+                .replace(/\\/g, '')
                 .replace(/\\(\[)|\\(\])|\[([^\]\[]*)\]|\\(.)/g, function (
                     matched,
                     p1,


### PR DESCRIPTION
Fixes [https://github.com/zyab1ik/blogify/security/code-scanning/50](https://github.com/zyab1ik/blogify/security/code-scanning/50)

To fix the problem, we need to ensure that all occurrences of the backslash character are replaced in the `unescapeFormat` function. This can be achieved by using a regular expression with the global flag (`g`). This change will ensure that every backslash in the input string is replaced, not just the first one.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
