### PR TITLE
Fix code scanning alert no. 51: Incomplete string escaping or encoding

### DIFF
--- a/public/plugins/jquery-ui/jquery-ui.js
+++ b/public/plugins/jquery-ui/jquery-ui.js
@@ -17929,7 +17929,7 @@ $.widget( "ui.tabs", {
 	},
 
 	_sanitizeSelector: function( hash ) {
-		return hash ? hash.replace( /[!"$%&'()*+,.\/:;<=>?@\[\]\^`{|}~]/g, "\\$&" ) : "";
+		return hash ? hash.replace( /[\\!"$%&'()*+,.\/:;<=>?@\[\]\^`{|}~]/g, "\\$&" ) : "";
 	},
 
 	refresh: function() {


### PR DESCRIPTION
Fixes [https://github.com/zyab1ik/blogify/security/code-scanning/51](https://github.com/zyab1ik/blogify/security/code-scanning/51)

To fix the problem, we need to ensure that backslashes are also escaped in the `hash` string. This can be achieved by modifying the regular expression used in the `replace` method to include backslashes. Additionally, we should use a regular expression with the `g` flag to ensure that all occurrences of special characters are replaced.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
