### PR TITLE
Fix code scanning alert no. 37: DOM text reinterpreted as HTML

### DIFF
--- a/public/assets/vendors/bootstrap/js/dist/carousel.js
+++ b/public/assets/vendors/bootstrap/js/dist/carousel.js
@@ -607,7 +607,7 @@
         return;
       }
 
-      var target = $(selector)[0];
+      var target = $.find(selector)[0];
 
       if (!target || !$(target).hasClass(ClassName.CAROUSEL)) {
         return;

--- a/public/assets/vendors/bootstrap/js/dist/util.js
+++ b/public/assets/vendors/bootstrap/js/dist/util.js
@@ -90,7 +90,8 @@
       }
 
       try {
-        return document.querySelector(selector) ? selector : null;
+        var sanitizedSelector = document.querySelector(selector) ? selector : null;
+        return sanitizedSelector && sanitizedSelector.replace(/[^a-zA-Z0-9-_#]/g, '');
       } catch (err) {
         return null;
       }


### PR DESCRIPTION
Fixes [https://github.com/zyab1ik/blogify/security/code-scanning/37](https://github.com/zyab1ik/blogify/security/code-scanning/37)

To fix the problem, we need to ensure that the `selector` derived from the `data-target` attribute is properly sanitized before being used in a jQuery selector. One way to achieve this is by using a more restrictive method to select elements, such as `$.find`, which interprets the input strictly as a CSS selector and not as HTML.

- Modify the `getSelectorFromElement` function in `public/assets/vendors/bootstrap/js/dist/util.js` to return a sanitized selector.
- Update the usage of the `selector` in `public/assets/vendors/bootstrap/js/dist/carousel.js` to use `$.find` instead of `$`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
