### PR TITLE
Fix code scanning alert no. 40: DOM text reinterpreted as HTML

### DIFF
--- a/public/assets/vendors/bootstrap/js/src/carousel.js
+++ b/public/assets/vendors/bootstrap/js/src/carousel.js
@@ -549,7 +549,7 @@ class Carousel {
       return
     }
 
-    const target = $(selector)[0]
+    const target = document.querySelector(selector)
 
     if (!target || !$(target).hasClass(ClassName.CAROUSEL)) {
       return

--- a/public/assets/vendors/bootstrap/js/src/util.js
+++ b/public/assets/vendors/bootstrap/js/src/util.js
@@ -82,7 +82,14 @@ const Util = {
       selector = hrefAttr && hrefAttr !== '#' ? hrefAttr.trim() : ''
     }
 
+    if (!selector) {
+      return null
+    }
+
     try {
+      const $temp = document.createElement('div')
+      $temp.innerHTML = selector
+      selector = $temp.textContent || $temp.innerText || ''
       return document.querySelector(selector) ? selector : null
     } catch (err) {
       return null


### PR DESCRIPTION
Fixes [https://github.com/zyab1ik/blogify/security/code-scanning/40](https://github.com/zyab1ik/blogify/security/code-scanning/40)

To fix the problem, we need to ensure that the `selector` is properly sanitized before being used in a jQuery selector. We can achieve this by using a more restrictive method to select elements, such as `document.querySelector`, which does not interpret the input as HTML. Additionally, we should ensure that the `selector` is a valid CSS selector and does not contain any potentially dangerous characters.

1. Modify the `getSelectorFromElement` function in `public/assets/vendors/bootstrap/js/src/util.js` to sanitize the `selector`.
2. Update the `_dataApiClickHandler` function in `public/assets/vendors/bootstrap/js/src/carousel.js` to use the sanitized `selector`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
