### PR TITLE
Fix code scanning alert no. 39: DOM text reinterpreted as HTML

### DIFF
--- a/public/assets/vendors/bootstrap/dist/js/bootstrap.bundle.js
+++ b/public/assets/vendors/bootstrap/dist/js/bootstrap.bundle.js
@@ -1149,7 +1149,7 @@
         return;
       }
 
-      var target = $(selector)[0];
+      var target = $.find(selector)[0];
 
       if (!target || !$(target).hasClass(ClassName$2.CAROUSEL)) {
         return;


### PR DESCRIPTION
Fixes [https://github.com/zyab1ik/blogify/security/code-scanning/39](https://github.com/zyab1ik/blogify/security/code-scanning/39)

To fix the problem, we need to ensure that the `selector` value is properly sanitized before it is used in the jQuery `$` function. One way to achieve this is by using the `$.find` function instead of `$`, as `$.find` interprets the `selector` strictly as a CSS selector and not as HTML. This change will prevent the execution of arbitrary JavaScript.

We will modify the code in the `Carousel._dataApiClickHandler` function to use `$.find` instead of `$` when handling the `selector`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
