### PR TITLE
Fix code scanning alert no. 96: Prototype-polluting function

### DIFF
--- a/public/plugins/overlayScrollbars/js/OverlayScrollbars.js
+++ b/public/plugins/overlayScrollbars/js/OverlayScrollbars.js
@@ -586,6 +586,10 @@
                     if ((options = arguments[i]) != null) {
                         // Extend the base object
                         for (name in options) {
+                            // Skip prototype pollution properties
+                            if (name === "__proto__" || name === "constructor") {
+                                continue;
+                            }
                             src = target[name];
                             copy = options[name];
 


### PR DESCRIPTION
Fixes [https://github.com/zyab1ik/blogify/security/code-scanning/96](https://github.com/zyab1ik/blogify/security/code-scanning/96)

To fix the problem, we need to ensure that properties like `__proto__` and `constructor` are not copied from `options` to `target`. This can be done by adding a check to skip these properties during the merge process. 

The best way to fix this without changing existing functionality is to modify the loop that copies properties from `options` to `target` to include a check that skips `__proto__` and `constructor`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
