### PR TITLE
Fix code scanning alert no. 112: DOM text reinterpreted as HTML

### DIFF
--- a/public/assets/vendors/bootstrap/js/src/util.js
+++ b/public/assets/vendors/bootstrap/js/src/util.js
@@ -87,9 +87,11 @@ const Util = {
     }
 
     try {
-      const $temp = document.createElement('div')
-      $temp.innerHTML = selector
-      selector = $temp.textContent || $temp.innerText || ''
+      // Validate the selector to ensure it only contains safe characters
+      const safeSelectorPattern = /^[#.\w-]+$/
+      if (!safeSelectorPattern.test(selector)) {
+        return null
+      }
       return document.querySelector(selector) ? selector : null
     } catch (err) {
       return null


### PR DESCRIPTION
Fixes [https://github.com/zyab1ik/blogify/security/code-scanning/112](https://github.com/zyab1ik/blogify/security/code-scanning/112)

To fix the problem, we need to ensure that the `selector` is properly sanitized before being used. Instead of setting the `innerHTML` property, we can use a safer method to handle the `selector` value. One approach is to use a regular expression to validate the `selector` and ensure it only contains safe characters.

- Replace the code that sets the `innerHTML` property with a safer alternative.
- Validate the `selector` using a regular expression to ensure it only contains safe characters.
- Update the `getSelectorFromElement` function to implement these changes.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
